### PR TITLE
[FIX] AWS 의존성 버전 통일

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,9 +86,15 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-ses</artifactId>
-            <version>1.11.227</version>
+            <version>1.12.669</version>
         </dependency>
 
+        <!-- aws s3 -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>1.12.669</version>
+        </dependency>
 
         <!-- Spring -->
         <dependency>
@@ -183,13 +189,6 @@
                 </exclusion>
             </exclusions>
             <scope>runtime</scope>
-        </dependency>
-
-        <!-- amazon s3 -->
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.12.638</version>
         </dependency>
 
 


### PR DESCRIPTION
## 문제 발생 상황
- 이미지 업로드 시 로컬에서는 문제가 없었으나 개발 서버 환경에서는 다음과 같은 에러가 발생하였습니다.
```
Handler dispatch failed; nested exception is java.lang.NoSuchFieldError: SERVICE_ID
```

## 문제 원인 파악
- AWS 서비스로는 S3 와 SES 를 사용하고 있습니다.
- S3 관련 코드에 변경점이 전혀 없었으나 문제가 발생한 것으로 보아 S3 관련 코드의 문제는 아니라고 파악하였습니다.
- 여러 AWS 의존성 사이에 버전 충돌 문제로 발생했다는 경우를 보고 일단 반영해보았습니다.
- 실제로 해결될지는 배포해보고 확인해봐야 알 수 있을 듯 합니다..
